### PR TITLE
fix: close sidebar in mobile on when page changes

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -22,6 +22,8 @@ export default class App {
       }
     } catch {
       window.location.hash = '#404';
+    } finally {
+      document.querySelector('.navigation')?.classList.add('hidden');
     }
   }
 }


### PR DESCRIPTION
Closes #26 

Cuando se navegaba en mobile y se cambiaba la página era bastante molesto porque había que cerrar el sidebar manulmente.
Este commit arregla ese problema, haciendo que el sidebar se cierre automáticamente