### PR TITLE
2021 10 06 routes as map

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -1,4 +1,3 @@
-import type View from './abstract/View';
 import getCurrentRoute from './helpers/getCurrentRoute';
 import setupLoginOnStartup from './helpers/setupLoginOnStartup';
 import selectRoute from './routes';
@@ -13,17 +12,10 @@ export default class App {
     this.navigate(getCurrentRoute());
   }
 
-  private async navigate(route: string): Promise<void> {
-    try {
-      const selectedRoute: View = selectRoute(route, this.el);
-      await selectedRoute.render();
-      if (selectedRoute.addEvents) {
-        selectedRoute.addEvents();
-      }
-    } catch {
-      window.location.hash = '#404';
-    } finally {
-      document.querySelector('.navigation')?.classList.add('hidden');
-    }
+  private navigate(route: string): void {
+    const SelectedRoute = selectRoute(route);
+    const view = new SelectedRoute(this.el);
+    view.render();
+    document.querySelector('.navigation')?.classList.add('hidden');
   }
 }

--- a/src/app/abstract/View.ts
+++ b/src/app/abstract/View.ts
@@ -10,8 +10,6 @@ abstract class View {
   }
 
   public render(): void {
-    this.el.innerHTML = '';
-
     if (this.addEvents) {
       this.addEvents();
     }

--- a/src/app/abstract/View.ts
+++ b/src/app/abstract/View.ts
@@ -9,7 +9,13 @@ abstract class View {
     this.el = el;
   }
 
-  public abstract render(): void;
+  public render(): void {
+    this.el.innerHTML = '';
+
+    if (this.addEvents) {
+      this.addEvents();
+    }
+  }
 }
 
 export default View;

--- a/src/app/routes/index.ts
+++ b/src/app/routes/index.ts
@@ -1,4 +1,4 @@
-import type View from '../abstract/View';
+import type ViewAdapter from '../types/ViewAdapter';
 import ProductDetails from '../views/ProductDetails';
 import ProductList from '../views/ProductList';
 import Home from '../views/Home';
@@ -6,16 +6,16 @@ import Login from '../views/Login';
 import NotFound from '../views/NotFound';
 import Favorites from '../views/Favorites';
 
-const routes: Record<string, typeof View> = {
-  '': Home,
-  '#product-list': ProductList,
-  '#product-details': ProductDetails,
-  '#favorites': Favorites,
-  '#login': Login,
-  '#404': NotFound,
-};
+const routes: Map<string, ViewAdapter> = new Map([
+  ['', Home],
+  ['#product-list', ProductList],
+  ['#product-details', ProductDetails],
+  ['#favorites', Favorites],
+  ['#login', Login],
+  ['#404', NotFound],
+]);
 
-export default function selectRoute(route: string, el: HTMLElement): View {
-  // eslint-disable-next-line
-  return new (<any>routes[route])(el);
+export default function selectRoute(route: string): ViewAdapter {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return routes.has(route) ? routes.get(route)! : routes.get('#404')!;
 }

--- a/src/app/types/ViewAdapter.ts
+++ b/src/app/types/ViewAdapter.ts
@@ -1,0 +1,9 @@
+import type View from '../abstract/View';
+
+/**
+ * Allows abstract class View to be instantiated.
+ * This has to be done to be able to instantiate its derived classes using polymorphism.
+ */
+type ViewAdapter = Pick<typeof View, keyof typeof View> & (new (el: HTMLElement) => View);
+
+export default ViewAdapter;

--- a/src/app/views/Favorites.ts
+++ b/src/app/views/Favorites.ts
@@ -28,6 +28,7 @@ export default class Favorites extends View {
         </div>
       </div>
     `;
+    super.render();
   }
 
   public addEvents(): void {

--- a/src/app/views/Home.ts
+++ b/src/app/views/Home.ts
@@ -25,5 +25,6 @@ export default class Home extends View {
       </article>
     </section>
     `;
+    super.render();
   }
 }

--- a/src/app/views/Login.ts
+++ b/src/app/views/Login.ts
@@ -15,6 +15,7 @@ export default class Login extends View {
     </form>
     <output id="output" class="text-red">
     `;
+    super.render();
   }
 
   private static async authenticateUser(user: string, email: string, output: HTMLOutputElement) {

--- a/src/app/views/NotFound.ts
+++ b/src/app/views/NotFound.ts
@@ -3,5 +3,6 @@ import View from '../abstract/View';
 export default class NotFound extends View {
   public render(): void {
     this.el.innerHTML = '<p class="text-red">Error 404: la página solicitada no fue encontrada</p>';
+    super.render();
   }
 }

--- a/src/app/views/ProductDetails.ts
+++ b/src/app/views/ProductDetails.ts
@@ -32,6 +32,7 @@ export default class ProductDetails extends View {
       const err = error as Error;
       this.el.innerHTML = getErrorMsgInnerHTML(err.message);
     }
+    super.render();
   }
 
   private toggleFavorite(): void {

--- a/src/app/views/ProductList.ts
+++ b/src/app/views/ProductList.ts
@@ -15,5 +15,6 @@ export default class ProductList extends View {
         ${catalog.products.reduce((a: string, b: Book): string => a + getListItemInnerHTML(b), '')}
       </div>
     `;
+    super.render();
   }
 }


### PR DESCRIPTION
Cambios introducidos:
* `routes` pasó de ser `object` a `Map`
* `selectRoute` ya no devuelve una instancia de un objeto, sino una referencia a una clase que se instancia luego
* como  `View` es una clase abstracta y no se puede instanciar, se creó un tipo para poder instanciar sus clases derivadas, aunque estén tipadas como `View`
* se removió el bloque `try`/`catch`/`finally` de `App.navigate` ya que ahora  `selectRoute` devuelve directamente la clase `NotFound` si la ruta es incorrecta